### PR TITLE
Fix ValidAccountName and ValidURI regexps

### DIFF
--- a/x/configuration/genesis.go
+++ b/x/configuration/genesis.go
@@ -32,8 +32,8 @@ func DefaultGenesisState() types.GenesisState {
 	config := types.Config{
 		Configurer:             "wasm1enqynlqt9wm6yskcn3ek5cld0ywjphwt0hktf5", // msig1
 		ValidDomainName:        "^[-_a-z0-9]{4,16}$",
-		ValidAccountName:       "[-_\\.a-z0-9]{1,64}$",
-		ValidURI:               "[-a-z0-9A-Z:]+$",
+		ValidAccountName:       "^[-_\\.a-z0-9]{1,64}$",
+		ValidURI:               "^[-a-z0-9A-Z:]+$",
 		ValidResource:          "^[a-z0-9A-Z]+$",
 		DomainRenewalPeriod:    31557600 * 1e9,
 		DomainRenewalCountMax:  2,


### PR DESCRIPTION
The `ValidAccountName` and `ValidURI` regular expressions missed a starting caret, thus matching strings starting with any amount of possibly unwanted characters.

This PR fixes that problem by adding a leading caret to those two regular expressions.