### PR TITLE
Add wasmvm/api to LD_LIBRARY_PATH

### DIFF
--- a/contrib/gitian-descriptors/starnamed-linux.yml
+++ b/contrib/gitian-descriptors/starnamed-linux.yml
@@ -72,7 +72,7 @@ script: |
   popd
 
   # allow gcc to pick-up libwasmvm.so
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(go list -f '{{ .Dir }}' -m github.com/CosmWasm/wasmvm)/api"
+  export LIBRARY_PATH="${LIBRARY_PATH}:$(go list -f '{{ .Dir }}' -m github.com/CosmWasm/wasmvm)/api"
 
   # Configure LDFLAGS for reproducible builds
   LDFLAGS="-extldflags=-static -buildid=${VERSION} -s -w \


### PR DESCRIPTION
Avoid ./starnamed-build-linux/var/build.log:/usr/bin/ld: cannot find -lwasmvm.