### PR TITLE
Keep it simple

### DIFF
--- a/contrib/gitian-descriptors/starnamed-linux.yml
+++ b/contrib/gitian-descriptors/starnamed-linux.yml
@@ -71,36 +71,14 @@ script: |
   go mod download
   popd
 
-  # allow gcc to pick-up libwasmvm.so
-  export LIBRARY_PATH="${LIBRARY_PATH}:$(go list -f '{{ .Dir }}' -m github.com/CosmWasm/wasmvm)/api"
-
-  # Configure LDFLAGS for reproducible builds
-  LDFLAGS="-extldflags=-static -buildid=${VERSION} -s -w \
-    -X github.com/cosmos/cosmos-sdk/version.AppName=starnamed \
-    -X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
-    -X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
-    -X github.com/iov-one/starnamed/app.Bech32Prefix=star \
-    -X github.com/iov-one/starnamed/app.CoinTypeStr=234 \
-    -X github.com/iov-one/starnamed/app.NodeDir=.starnamed \
-    -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger"
-
   # Extract release tarball and build
   for arch in ${ARCHS}; do
     INSTALLPATH=`pwd`/installed/${DISTNAME}-${arch}
     mkdir -p ${INSTALLPATH}
 
-    # Build starnamed tool suite
+    # Build starnamed
     pushd ${distsrc}
-    for prog in starnamed; do
-      GOARCH=${arch} GOROOT_FINAL=${GOROOT} go build -a \
-        -trimpath \
-        -gcflags=all=-trimpath=${GOPATH} \
-        -asmflags=all=-trimpath=${GOPATH} \
-        -mod=readonly -tags "netgo ledger" \
-        -ldflags="${LDFLAGS}" \
-        -o ${INSTALLPATH}/${prog} ./cmd/${prog}
-
-    done
+    make install
     popd # ${distsrc}
 
     pushd ${INSTALLPATH}


### PR DESCRIPTION
Note that the trimpaths on `-gcflags` and `-asmflags` that were previously applied should be suspects if build signatures across machines don't match.

If the faucet or block-metrics needs to be gitian built then just do `( cd cmd/faucet && make install)` after starnamed's `make install`.

Being clever with LIBRARY_PATH was futile, likely due to the number of backslashes required to escape the `!`s in the wasmvm path when getting
processed through yaml, etc.