### PR TITLE
Add libwasmvm.so to the gitian build

### DIFF
--- a/contrib/gitian-descriptors/starnamed-linux.yml
+++ b/contrib/gitian-descriptors/starnamed-linux.yml
@@ -80,6 +80,7 @@ script: |
     pushd ${distsrc}
     sed -i "0,/VERSION/{s/VERSION.*/VERISION=${VERSION}/}" Makefile # HACK
     sed -i "0,/COMMIT/{s/COMMIT.*/COMMIT=${COMMIT}/}" Makefile # HACK
+    sed -i "0,/BUILD_FLAGS/{s@BUILD_FLAGS.*@& -gcflags=all=-trimpath=${GOPATH} -asmflags=all=-trimpath=${GOPATH}@}" Makefile # HACK
     make install
     cp -av "$(go list -f '{{ .Dir }}' -m github.com/CosmWasm/wasmvm)/api/libwasmvm.so" ${GOPATH}/bin
     popd # ${distsrc}

--- a/contrib/gitian-descriptors/starnamed-linux.yml
+++ b/contrib/gitian-descriptors/starnamed-linux.yml
@@ -76,11 +76,12 @@ script: |
     INSTALLPATH=`pwd`/installed/${DISTNAME}-${arch}
     mkdir -p ${INSTALLPATH}
 
-    # Build starnamed
+    # Build starnamed and copy libwasmvm.so next to it
     pushd ${distsrc}
     sed -i "0,/VERSION/{s/VERSION.*/VERISION=${VERSION}/}" Makefile # HACK
     sed -i "0,/COMMIT/{s/COMMIT.*/COMMIT=${COMMIT}/}" Makefile # HACK
     make install
+    cp -av "$(go list -f '{{ .Dir }}' -m github.com/CosmWasm/wasmvm)/api/libwasmvm.so" ${GOPATH}/bin
     popd # ${distsrc}
 
     pushd ${GOPATH}/bin


### PR DESCRIPTION
We need to ship `libwasmvm.so` along with `starnamed` in order to avoid `/opt/iovns/bin/starnamed: error while loading shared libraries: libwasmvm.so: cannot open shared object file: No such file or directory`.