### PR TITLE
Fix cosmos swagger.yaml missing

### DIFF
--- a/scripts/fetch-cosmos-swagger.sh
+++ b/scripts/fetch-cosmos-swagger.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eo pipefail
+
+SCRIPT_DIR=$(dirname $0)
+GO_MOD_FILE=$SCRIPT_DIR/../go.mod
+COSMOS_VERSION=$(grep github.com/cosmos/cosmos-sdk $GO_MOD_FILE|cut -d " " -f 2)
+SWAGGER_URL=https://raw.githubusercontent.com/cosmos/cosmos-sdk/$COSMOS_VERSION/client/docs/swagger-ui/swagger.yaml
+
+SWAGGER_DEST=$SCRIPT_DIR/../client/docs/swagger-ui/swagger.yaml
+
+wget $SWAGGER_URL -q -O $SWAGGER_DEST 1> /dev/null

--- a/scripts/protoc-swagger-gen.sh
+++ b/scripts/protoc-swagger-gen.sh
@@ -26,5 +26,8 @@ swagger-combine ./client/docs/config.json -o ./client/docs/swagger-ui/swagger-st
 # clean swagger files
 rm -rf ./tmp-swagger-gen
 
+# Update the Cosmos SDK yaml file
+scripts/fetch-cosmos-swagger.sh
+
 # Update static assets
 statik -src client/docs/swagger-ui/ -dest client/docs/ -f -m


### PR DESCRIPTION
The swagger.yaml file was missing so we now automatically fetch it from the correct Cosmos SDK version when we compile the swagger documentation